### PR TITLE
Fix a bug that the ephemeral volume is not deleted along with the vm.

### DIFF
--- a/bosh_cloudstack_cpi/lib/cloud/cloudstack/cloud.rb
+++ b/bosh_cloudstack_cpi/lib/cloud/cloudstack/cloud.rb
@@ -251,6 +251,14 @@ module Bosh::CloudStackCloud
           job = with_compute { server.destroy }
           wait_job(job)
 
+          settings = @registry.read_settings(server.name)
+          ephemeral_volume_id = settings["disks"]["ephemeral"]
+          volume = with_compute { @compute.volumes.get(ephemeral_volume_id) }
+          if volume
+            # Delete ephemeral volume
+            delete_disk(volume.id)
+          end
+
           @logger.info("Deleting settings for server `#{server.id}'...")
           @registry.delete_settings(server.name)
         else

--- a/bosh_cloudstack_cpi/spec/unit/delete_vm_spec.rb
+++ b/bosh_cloudstack_cpi/spec/unit/delete_vm_spec.rb
@@ -6,22 +6,63 @@ require "spec_helper"
 describe Bosh::CloudStackCloud::Cloud do
 
   before(:each) do
-     @registry = mock_registry
-   end
-
-  it "deletes an CloudStack server" do
-    server = double("server", :id => "i-foobar", :name => "i-foobar")
-    job = generate_job
-
-    cloud = mock_cloud do |compute|
-      compute.servers.should_receive(:get).with("i-foobar").and_return(server)
-    end
-
-    server.should_receive(:destroy).and_return(job)
-    cloud.should_receive(:wait_job).with(job)
-
-    @registry.should_receive(:delete_settings).with("i-foobar")
-
-    cloud.delete_vm("i-foobar")
+    @server = double("server")
+    @volume = double("volume")
+    @registry = mock_registry
+    @job = generate_job
+    @ephemeral_settings =
+      {
+        "disks" => {
+          "persistent"=>{},
+          "ephemeral"=>"/dev/sdb",
+        }
+      }
+    @no_ephemeral_settings =
+      {
+        "disks" => {
+          "persistent"=>{},
+          "ephemeral"=>nil
+        }
+      }
   end
+
+  it "deletes no CloudStack server" do
+    cloud = mock_cloud do |compute|
+      compute.servers.should_receive(:get).with("i-no_server").and_return(nil)
+    end
+    cloud.delete_vm("i-no_server")
+  end
+
+  it "deletes the CloudStack server without an ephemeral disk" do
+    cloud = mock_cloud do |compute|
+      compute.servers.should_receive(:get).with("i-no_ephemeral").and_return(@server)
+      compute.volumes.should_receive(:get).with(nil).and_return(nil)
+    end
+    @server.should_receive(:id).and_return("i-no_ephemeral")
+    @server.should_receive(:name).exactly(2).and_return("i-no_ephemeral")
+    @server.should_receive(:destroy).and_return(@job)
+    cloud.should_receive(:wait_job).with(@job)
+    @registry.should_receive(:read_settings).with("i-no_ephemeral").and_return(@no_ephemeral_settings)
+    @registry.should_receive(:delete_settings).with("i-no_ephemeral")
+
+    cloud.delete_vm("i-no_ephemeral")
+  end
+
+  it "deletes the CloudStack server with the ephemeral disk" do
+    cloud = mock_cloud do |compute|
+      compute.servers.should_receive(:get).with("i-ephemeral").and_return(@server)
+      compute.volumes.should_receive(:get).with("/dev/sdb").and_return(@volume)
+    end
+    @server.should_receive(:id).and_return("i-ephemeral")
+    @server.should_receive(:name).exactly(2).and_return("i-ephemeral")
+    @volume.should_receive(:id).and_return("volume-ephemeral")
+    @registry.should_receive(:read_settings).with("i-ephemeral").and_return(@ephemeral_settings)
+    cloud.should_receive(:delete_disk).with("volume-ephemeral")
+    @server.should_receive(:destroy).and_return(@job)
+    cloud.should_receive(:wait_job).with(@job)
+    @registry.should_receive(:delete_settings).with("i-ephemeral")
+
+    cloud.delete_vm("i-ephemeral")
+  end
+
 end


### PR DESCRIPTION
In the following file, add the process of deleting the ephemeral volume.
- bosh_cloudstack_cpi/lib/cloud/cloudstack/cloud.rb#delete_vm

In the following file, add the unit test.
- bosh_cloudstack_cpi/spec/unit/delete_vm_spec.rb
